### PR TITLE
Fix uninitialized gender state

### DIFF
--- a/lib/screens/input_page.dart
+++ b/lib/screens/input_page.dart
@@ -19,7 +19,7 @@ class InputPage extends StatefulWidget {
 }
 
 class _InputPageState extends State<InputPage> {
-  late Gender selectedGender;
+  Gender? selectedGender;
   int height = 180;
   int weight = 60;
   int age = 20;


### PR DESCRIPTION
## Summary
- avoid late initialization error for `selectedGender`

## Testing
- `dart pub get` *(fails: Flutter SDK not available)*
- `dart test` *(fails: Flutter SDK not available)*

------
https://chatgpt.com/codex/tasks/task_e_6853034a88908320b23887574e57dcc5