### PR TITLE
Add versions to Flutter icons

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,8 +10,8 @@ dependencies:
   flutter:
     sdk: flutter
 
-  cupertino_icons:
-  font_awesome_flutter:
+  cupertino_icons: ^1.0.6
+  font_awesome_flutter: ^10.8.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- specify explicit versions for icon dependencies in `pubspec.yaml`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68530642e2a083209352eb2d52d568b1