### PR TITLE
Fix actions deprecation in workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
         run: flutter build apk --release
 
       - name: Upload APK Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: android-app
           path: build/app/outputs/flutter-apk/app-release.apk


### PR DESCRIPTION
## Summary
- update `actions/upload-artifact` to use v4 in the workflow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853096f1b188320be5d7b517d7c56c0